### PR TITLE
ref: skip resource update when demand is 0

### DIFF
--- a/src/main/java/de/uos/informatik/ko/rcp/generators/EarliestStartScheduleGenerator.java
+++ b/src/main/java/de/uos/informatik/ko/rcp/generators/EarliestStartScheduleGenerator.java
@@ -130,8 +130,13 @@ public class EarliestStartScheduleGenerator {
 
             // Update resource profiles
             for (int resIdx = 0; resIdx < this.instance.r(); ++resIdx) {
-                var availibilityByTime = availableRessources[resIdx];
                 final var demand = curDemands[resIdx];
+
+                if (demand == 0) {
+                    continue;
+                }
+
+                var availibilityByTime = availableRessources[resIdx];
 
                 for (int tau = startTime; tau < startTime + curProcTime; ++tau) {
                     availibilityByTime[tau] = availibilityByTime[tau] - demand;


### PR DESCRIPTION
When the demand for a particular resource is 0, we can forgo updating resource profiles and jump times.

Closes #19.