### PR TITLE
feat: add `Config` class for CLI flag management

### DIFF
--- a/src/main/java/de/uos/informatik/ko/rcp/Config.java
+++ b/src/main/java/de/uos/informatik/ko/rcp/Config.java
@@ -1,0 +1,51 @@
+package de.uos.informatik.ko.rcp;
+
+public class Config {
+    public static enum Crossover {
+        ONE_POINT,
+        TWO_POINT
+    }
+
+    public static enum ParentSelection {
+        FIXED_SIZE,
+        RANDOM_SIZE
+    }
+
+    static public void init(Crossover crossover, double mutationProbability,
+                            int noImprovementThreshold, ParentSelection parentSelection,
+                            boolean cacheMakespans, boolean shouldLog) {
+        if (Config.instance != null) {
+            throw new IllegalStateException("Config.init() called more than once");
+        }
+
+        Config.instance = new Config(crossover, mutationProbability, noImprovementThreshold,
+                                     parentSelection, cacheMakespans, shouldLog);
+    }
+
+    static public Config instance() {
+        if (Config.instance == null) {
+            throw new IllegalStateException("Config.init() must be called before " +
+                                            "Config.instance()");
+        }
+
+        return Config.instance;
+    }
+
+    private Config(Crossover crossover, double mutationProbability, int noImprovementThreshold,
+                   ParentSelection parentSelection, boolean cacheMakespans, boolean shouldLog) {
+        this.crossover = crossover;
+        this.mutationProbability = mutationProbability;
+        this.noImprovementThreshold = noImprovementThreshold;
+        this.parentSelection = parentSelection;
+        this.cacheMakespans = cacheMakespans;
+        this.shouldLog = shouldLog;
+    }
+
+    static private Config instance = null;
+    public final Crossover crossover;
+    public final double mutationProbability;
+    public final int noImprovementThreshold;
+    public final ParentSelection parentSelection;
+    public final boolean cacheMakespans;
+    public final boolean shouldLog;
+}

--- a/src/main/java/de/uos/informatik/ko/rcp/Main.java
+++ b/src/main/java/de/uos/informatik/ko/rcp/Main.java
@@ -11,6 +11,7 @@ import de.uos.informatik.ko.rcp.geneticalgorithm.GeneratePop;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.InvalidPathException;
+import java.util.Arrays;
 import java.util.Random;
 
 public class Main {
@@ -19,8 +20,8 @@ public class Main {
         Args args = null;
 
         try {
-            args = new Args(arguments);
-        } catch (IllegalArgumentException e) {
+            args = Args.parseArgs(arguments);
+        } catch (Exception e) {
             System.err.println("ERROR: " + e.getMessage());
             System.err.println("Usage: java -jar rcp-solver-0.1.0.jar <instance-path> "
                              + "<solution-path> <time-limit> <seed>");
@@ -51,7 +52,7 @@ public class Main {
         public final long timeLimit;
         public final long seed;
 
-        public Args(String[] args) {
+        private Args(String[] args) {
             if (args.length != 4) {
                 throw new IllegalArgumentException("Must provide four arguments.");
             }
@@ -75,6 +76,114 @@ public class Main {
             } catch (NumberFormatException e) {
                 throw new IllegalArgumentException("Cannot parse \"" + args[3] + "\" as a long");
             }
+        }
+
+        public static Args parseArgs(String[] args) {
+            // ---- The first 4 args must be provided
+            var fixedArgs = new Args(Arrays.copyOfRange(args, 0, 4));
+
+            // ---- Optional flags _may_ be provided
+            var crossover = Config.Crossover.TWO_POINT;
+            double mutationProbability = 0.4;
+            int noImprovementThreshold = 10;
+            var parentSelection = Config.ParentSelection.RANDOM_SIZE;
+            var cacheMakespans = true;
+            var shouldLog = false;
+
+            var flags = Arrays.stream(args).skip(4).iterator();
+            while (flags.hasNext()) {
+                var flag = flags.next();
+                var key_val = flag.split("=");
+                var key = key_val[0];
+                var val = key_val[1];
+
+                switch (key) {
+                    case "--crossover": {
+                        if (val.equals("one-point")) {
+                            crossover = Config.Crossover.ONE_POINT;
+                        } else if (val.equals("two-point")) {
+                            crossover = Config.Crossover.TWO_POINT;
+                        } else {
+                            System.err.println("Unknown crossover method \"" + val + "\"");
+                            System.exit(1);
+                        }
+                    }
+                    break;
+                    case "--mutation-probability": {
+                        try {
+                            mutationProbability = Double.parseDouble(val);
+                        } catch (NumberFormatException e) {
+                            System.err.println("Cannot parse double from \"" + val + "\"");
+                            System.exit(1);
+                        }
+
+                        if (mutationProbability < 0 || mutationProbability > 1) {
+                            System.err.println("Mutation probability must be between 0 and 1");
+                            System.exit(1);
+                        }
+                    }
+                    break;
+                    case "--no-improvement-threshold": {
+                        try {
+                            noImprovementThreshold = Integer.parseInt(val);
+                        } catch (NumberFormatException e) {
+                            System.err.println("Cannot parse int from \"" + val + "\"");
+                            System.exit(1);
+                        }
+
+                        if (noImprovementThreshold < 0) {
+                            System.err.println("Threshold for no improvements cannot be negative");
+                            System.exit(1);
+                        }
+                    }
+                    break;
+                    case "--parent-selection": {
+                        if (val.equals("fixed-size")) {
+                            parentSelection = Config.ParentSelection.FIXED_SIZE;
+                        } else if (val.equals("random-size")) {
+                            parentSelection = Config.ParentSelection.RANDOM_SIZE;
+                        } else {
+                            System.err.println("Unknown parent selection method \"" + val + "\"");
+                            System.exit(1);
+                        }
+                    }
+                    break;
+                    case "--cache-makespans": {
+                        if (val.equals("true")) {
+                            cacheMakespans = true;
+                        } else if (val.equals("false")) {
+                            cacheMakespans = false;
+                        } else {
+                            System.err.println("Value of cache-makespans must be true or false, " +
+                                               "not \"" + val + "\"");
+                            System.exit(1);
+                        }
+                    }
+                    break;
+                    case "--should-log": {
+                        if (val.equals("true")) {
+                            shouldLog = true;
+                        } else if (val.equals("false")) {
+                            shouldLog = false;
+                        } else {
+                            System.err.println("Value of should-log must be true or false, not " +
+                                               "\"" + val + "\"");
+                            System.exit(1);
+                        }
+                    }
+                    break;
+                    default: {
+                        System.err.println("Unknown flag \"" + flag + "\"");
+                        System.exit(1);
+                    }
+                    break;
+                }
+            }
+
+            Config.init(crossover, mutationProbability, noImprovementThreshold, parentSelection,
+                        cacheMakespans, shouldLog);
+
+            return fixedArgs;
         }
     }
 }


### PR DESCRIPTION
Supported flags:
- `--crossover=`: `one-point` or `two-point`
- `--mutation-probability=`: Double between 0 and 1
- `--no-improvement-threshold=`: Non-negative integer. If this is 0, do not introduce new members at all.
- `--parent-selection=`: `fixed-size` or `random-size`
- `--cache-makespans=`: `true` or `false`
- `--should-log=`: `true` or `false`

**Flags MUST be placed after the four required arguments or parsing will not work!**